### PR TITLE
Ignore unknown fields in LocalizedAssetBody

### DIFF
--- a/restclient/src/main/java/com/box/l10n/mojito/rest/entity/LocalizedAssetBody.java
+++ b/restclient/src/main/java/com/box/l10n/mojito/rest/entity/LocalizedAssetBody.java
@@ -1,6 +1,7 @@
 package com.box.l10n.mojito.rest.entity;
 
 import com.box.l10n.mojito.okapi.FilterConfigIdOverride;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import java.util.List;
 
 /**
@@ -9,6 +10,7 @@ import java.util.List;
  *
  * @author wyau
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class LocalizedAssetBody {
   public enum InheritanceMode {
 


### PR DESCRIPTION
To ensure backwards compatibilty, new fields should be ignorable by default.